### PR TITLE
Swift 6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,11 @@ jobs:
     strategy:
       matrix:
         swift:
-          - 5.7
-          - 5.8
-          - 5.9
+          - '5.7'
+          - '5.8'
+          - '5.9'
+          - '5.10'
+          - '6.0'
     container: swift:${{ matrix.swift }}
     steps:
       - uses: actions/checkout@v4

--- a/Package.swift
+++ b/Package.swift
@@ -36,5 +36,6 @@ let package = Package(
                 .product(name: "Benchmark", package: "swift-benchmark"),
             ]
         ),
-    ]
+    ],
+    swiftLanguageVersions: [.version("6"), .v5]
 )


### PR DESCRIPTION
## Background
- official migration guidelines: https://www.swift.org/migration/documentation/swift-6-concurrency-migration-guide/swift6mode/#Package-manifest

## Details
- enable Swift 6 language mode
- update CI workflow for Swift 6.0
- (we don't need any changes to the code base 👏 )