### PR TITLE
Drop Swift 5.x toolchain support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,10 @@ jobs:
     strategy:
       matrix:
         swift:
-          - '5.7'
-          - '5.8'
-          - '5.9'
-          - '5.10'
           - '6.0'
+          - '6.1'
+          - '6.2'
+          - '6.3'
     container: swift:${{ matrix.swift }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,4 +1,4 @@
---swiftversion 5.7
+--swiftversion 6.0
 --nospaceoperators ...,..<
 --ifdef no-indent
 --trimwhitespace nonblank-lines

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -37,5 +37,5 @@ let package = Package(
             ]
         ),
     ],
-    swiftLanguageVersions: [.version("6"), .v5]
+    swiftLanguageModes: [.v6]
 )

--- a/Sources/LocalDate/Month.swift
+++ b/Sources/LocalDate/Month.swift
@@ -32,11 +32,11 @@ public enum Month: UInt8, CaseIterable, Sendable {
     static func lengthOfMonth(_ month: Int, isLeapYear: Bool) -> Int {
         switch month {
         case 2:
-            return isLeapYear ? 29 : 28
+            isLeapYear ? 29 : 28
         case 4, 6, 9, 11:
-            return 30
+            30
         default:
-            return 31
+            31
         }
     }
 }


### PR DESCRIPTION
## Summary

- Raise the package tools version from Swift 5.7 to Swift 6.0
- Remove Swift 5.x from the declared Swift language modes
- Update Linux CI to test Swift 6.0, 6.1, 6.2, and 6.3
- Update SwiftFormat configuration to target Swift 6.0

## Details

This drops support for building with Swift 5.x toolchains. The package manifest now uses SwiftPM's Swift 6 manifest API via `swiftLanguageModes: [.v6]`.

Updating SwiftFormat's `--swiftversion` to `6.0` surfaced a redundant `return` lint issue in `Month.lengthOfMonth`, which was fixed by using the Swift 6 switch expression form.

## Verification

- `swift package describe`
- `swift run swiftformat . --lint`
- `swift test`
- `xcodebuild build -workspace swift-local-date.xcworkspace -scheme LocalDate -destination platform=macOS`
- `xcodebuild build -workspace swift-local-date.xcworkspace -scheme swift-local-date-benchmark -destination platform=macOS`