### PR TITLE
Enable SwiftTesting test case name formatting

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -10,4 +10,3 @@
 --hexgrouping none
 --header strip
 --enable blankLineAfterImports,blankLinesBetweenImports,blockComments,docComments,isEmpty,wrapConditionalBodies
---disable swiftTestingTestCaseNames

--- a/Tests/LocalDateTests/LocalDateTests.swift
+++ b/Tests/LocalDateTests/LocalDateTests.swift
@@ -12,21 +12,21 @@ struct LocalDateTests {
     }
 
     @Test
-    func test_init_from_date_in_timeZone() throws {
+    func init_from_date_in_timeZone() throws {
         #expect(try LocalDate(from: Date(timeIntervalSince1970: 0), in: #require(TimeZone(secondsFromGMT: 0))) == LocalDate(year: 1970, month: 1, day: 1))
 
         #expect(try LocalDate(from: Date(timeIntervalSince1970: 0), in: #require(TimeZone(secondsFromGMT: -3600))) == LocalDate(year: 1969, month: 12, day: 31))
     }
 
     @Test
-    func test_init_from_string() throws {
+    func init_from_string() throws {
         #expect(try LocalDate(from: "1970-01-01") == LocalDate(year: 1970, month: 1, day: 1))
         #expect(try LocalDate(from: "1970-12-31") == LocalDate(year: 1970, month: 12, day: 31))
         #expect(try LocalDate(from: "-0001-01-01") == LocalDate(year: -1, month: 1, day: 1))
     }
 
     @Test
-    func test_init_from_string_error() {
+    func init_from_string_error() {
         #expect(throws: FormatError()) {
             try LocalDate(from: "")
         }
@@ -69,7 +69,7 @@ struct LocalDateTests {
     }
 
     @Test
-    func test_date_in_timeZone() throws {
+    func date_in_timeZone() throws {
         #expect(try LocalDate(year: 1970, month: 1, day: 1).date(in: #require(TimeZone(secondsFromGMT: 0))) == Date(timeIntervalSince1970: 0))
 
         #expect(try LocalDate(year: 1970, month: 1, day: 1).date(in: #require(TimeZone(secondsFromGMT: -3600))) == Date(timeIntervalSince1970: 3600))
@@ -83,13 +83,13 @@ struct LocalDateTests {
     }
 
     @Test
-    func test_init_from_description() {
+    func init_from_description() {
         #expect(LocalDate("19700101") == nil)
         #expect(LocalDate(LocalDate(year: 1970, month: 1, day: 1).description) == LocalDate(year: 1970, month: 1, day: 1))
     }
 
     @Test
-    func test_init_from_decoder() throws {
+    func init_from_decoder() throws {
         #expect(try JSONDecoder().decode(LocalDate.self, from: Data("\"1970-01-01\"".utf8)) == LocalDate(year: 1970, month: 1, day: 1))
 
         #if compiler(>=6.1)
@@ -115,12 +115,12 @@ struct LocalDateTests {
     }
 
     @Test
-    func test_encode_to_encoder() throws {
+    func encode_to_encoder() throws {
         #expect(try JSONEncoder().encode(LocalDate(year: 1970, month: 1, day: 1)) == Data("\"1970-01-01\"".utf8))
     }
 
     @Test
-    func test_comparable() {
+    func comparable() {
         #expect(LocalDate(year: 1969, month: 12, day: 31) < LocalDate(year: 1970, month: 1, day: 1))
 
         #expect(LocalDate(year: 1970, month: 1, day: 1) < LocalDate(year: 1970, month: 2, day: 1))

--- a/Tests/LocalDateTests/LocalDateTimeTests.swift
+++ b/Tests/LocalDateTests/LocalDateTimeTests.swift
@@ -24,14 +24,14 @@ struct LocalDateTimeTests {
     }
     
     @Test
-    func test_init_from_date_in_timeZone() throws {
+    func init_from_date_in_timeZone() throws {
         #expect(try LocalDateTime(from: Date(timeIntervalSince1970: 0), in: #require(TimeZone(secondsFromGMT: 0))) == LocalDateTime(year: 1970, month: 1, day: 1, hour: 0, minute: 0, second: 0, nanosecond: 0))
         
         #expect(try LocalDateTime(from: Date(timeIntervalSince1970: 3599), in: #require(TimeZone(secondsFromGMT: -3600))) == LocalDateTime(year: 1969, month: 12, day: 31, hour: 23, minute: 59, second: 59, nanosecond: 0))
     }
     
     @Test
-    func test_init_from_string() throws {
+    func init_from_string() throws {
         #expect(try LocalDateTime(from: "1970-01-01T23:59:59.9") == LocalDateTime(
             date: LocalDate(year: 1970, month: 1, day: 1),
             time: LocalTime(hour: 23, minute: 59, second: 59, nanosecond: 900000000)
@@ -39,7 +39,7 @@ struct LocalDateTimeTests {
     }
     
     @Test
-    func test_init_from_string_error() {
+    func init_from_string_error() {
         #expect(throws: FormatError()) {
             try LocalDateTime(from: "1970-01-01 23:59:59.9")
         }
@@ -57,7 +57,7 @@ struct LocalDateTimeTests {
     }
     
     @Test
-    func test_init_from_description() {
+    func init_from_description() {
         #expect(LocalDateTime("1970-12-31 01:02:03.4") == nil)
         #expect(LocalDateTime("1970-12-31T01:02:03.04") == LocalDateTime(
             date: LocalDate(year: 1970, month: 12, day: 31),
@@ -66,7 +66,7 @@ struct LocalDateTimeTests {
     }
     
     @Test
-    func test_init_from_decoder() throws {
+    func init_from_decoder() throws {
         #expect(try JSONDecoder().decode(LocalDateTime.self, from: Data("\"1970-12-31T01:02:03.4\"".utf8)) == LocalDateTime(
             date: LocalDate(year: 1970, month: 12, day: 31),
             time: LocalTime(hour: 1, minute: 2, second: 3, nanosecond: 400000000)
@@ -95,12 +95,12 @@ struct LocalDateTimeTests {
     }
     
     @Test
-    func test_encode_to_encoder() throws {
+    func encode_to_encoder() throws {
         #expect(try JSONEncoder().encode(LocalDateTime(year: 1970, month: 12, day: 31, hour: 1, minute: 2, second: 3, nanosecond: 4)) == Data("\"1970-12-31T01:02:03.000000004\"".utf8))
     }
     
     @Test
-    func test_comparable() {
+    func comparable() {
         #expect(LocalDateTime(year: 1970, month: 1, day: 1, hour: 0, minute: 0, second: 0, nanosecond: 0) < LocalDateTime(year: 1970, month: 1, day: 2, hour: 0, minute: 0, second: 0, nanosecond: 0))
         
         #expect(LocalDateTime(year: 1970, month: 1, day: 1, hour: 0, minute: 0, second: 0, nanosecond: 0) < LocalDateTime(year: 1970, month: 1, day: 1, hour: 0, minute: 0, second: 0, nanosecond: 1))

--- a/Tests/LocalDateTests/LocalTimeTests.swift
+++ b/Tests/LocalDateTests/LocalTimeTests.swift
@@ -13,14 +13,14 @@ struct LocalTimeTests {
     }
     
     @Test
-    func test_init_from_date_in_timeZone() throws {
+    func init_from_date_in_timeZone() throws {
         #expect(try LocalTime(from: Date(timeIntervalSince1970: 0), in: #require(TimeZone(secondsFromGMT: 0))) == LocalTime(hour: 0, minute: 0, second: 0, nanosecond: 0))
         
         #expect(try LocalTime(from: Date(timeIntervalSince1970: 3599), in: #require(TimeZone(secondsFromGMT: -3600))) == LocalTime(hour: 23, minute: 59, second: 59, nanosecond: 0))
     }
     
     @Test
-    func test_init_from_string() throws {
+    func init_from_string() throws {
         #expect(try LocalTime(from: "00:00:00") == LocalTime(hour: 0, minute: 0, second: 0, nanosecond: 0))
         #expect(try LocalTime(from: "23:59:59") == LocalTime(hour: 23, minute: 59, second: 59, nanosecond: 0))
         
@@ -32,7 +32,7 @@ struct LocalTimeTests {
     }
     
     @Test
-    func test_init_from_string_error() throws {
+    func init_from_string_error() throws {
         #expect(throws: FormatError()) {
             try LocalTime(from: "00:00:00.")
         }
@@ -52,13 +52,13 @@ struct LocalTimeTests {
     }
     
     @Test
-    func test_init_from_description() {
+    func init_from_description() {
         #expect(LocalTime("235959") == nil)
         #expect(LocalTime(LocalTime(hour: 1, minute: 2, second: 3, nanosecond: 4).description) == LocalTime(hour: 1, minute: 2, second: 3, nanosecond: 4))
     }
     
     @Test
-    func test_init_from_decoder() throws {
+    func init_from_decoder() throws {
         #expect(try JSONDecoder().decode(LocalTime.self, from: Data("\"01:02:03.4\"".utf8)) == LocalTime(hour: 1, minute: 2, second: 3, nanosecond: 400000000))
         
         #if compiler(>=6.1)
@@ -84,12 +84,12 @@ struct LocalTimeTests {
     }
     
     @Test
-    func test_encode_to_encoder() throws {
+    func encode_to_encoder() throws {
         #expect(try JSONEncoder().encode(LocalTime(hour: 1, minute: 2, second: 3, nanosecond: 4)) == Data("\"01:02:03.000000004\"".utf8))
     }
     
     @Test
-    func test_comparable() {
+    func comparable() {
         #expect(LocalTime(hour: 0, minute: 0, second: 0, nanosecond: 0) < LocalTime(hour: 0, minute: 0, second: 0, nanosecond: 1))
         
         #expect(LocalTime(hour: 0, minute: 0, second: 0, nanosecond: 0) < LocalTime(hour: 0, minute: 0, second: 1, nanosecond: 0))

--- a/Tests/LocalDateTests/MonthTests.swift
+++ b/Tests/LocalDateTests/MonthTests.swift
@@ -12,7 +12,7 @@ struct MonthTests {
     }
     
     @Test
-    func test_init_integerLiteral() {
+    func init_integerLiteral() {
         #expect(Month(1) == 1)
         #expect(Month(12) == 12)
         #expect(Month(integerLiteral: 1) == 1)
@@ -20,7 +20,7 @@ struct MonthTests {
     }
     
     @Test
-    func test_init_text() {
+    func init_text() {
         #expect(Month("0") == nil)
         #expect(Month("1") == Month(1))
         #expect(Month("12") == Month(12))
@@ -94,13 +94,13 @@ struct MonthTests {
     }
     
     @Test
-    func test_description() {
+    func description() {
         #expect(String(describing: Month(1)) == "1")
         #expect(String(describing: Month(12)) == "12")
     }
     
     @Test
-    func test_comparable() {
+    func comparable() {
         #expect(Month(1) < Month(2))
     }
 }

--- a/Tests/LocalDateTests/OffsetDateTimeTests.swift
+++ b/Tests/LocalDateTests/OffsetDateTimeTests.swift
@@ -30,14 +30,14 @@ struct OffsetDateTimeTests {
     }
 
     @Test
-    func test_init_from_date_in_timeZone() throws {
+    func init_from_date_in_timeZone() throws {
         #expect(try OffsetDateTime(from: Date(timeIntervalSince1970: 0), in: #require(TimeZone(secondsFromGMT: 0))) == OffsetDateTime(year: 1970, month: 1, day: 1, hour: 0, minute: 0, second: 0, nanosecond: 0, offset: ZoneOffset(second: 0)))
 
         #expect(try OffsetDateTime(from: Date(timeIntervalSince1970: 3599), in: #require(TimeZone(secondsFromGMT: -3600))) == OffsetDateTime(year: 1969, month: 12, day: 31, hour: 23, minute: 59, second: 59, nanosecond: 0, offset: ZoneOffset(second: -3600)))
     }
 
     @Test
-    func test_init_from_string() throws {
+    func init_from_string() throws {
         #expect(try OffsetDateTime(from: "1970-12-31T01:02:03.4+02:30") == OffsetDateTime(
             dateTime: LocalDateTime(year: 1970, month: 12, day: 31, hour: 1, minute: 2, second: 3, nanosecond: 400000000),
             offset: ZoneOffset(second: 9000)
@@ -53,7 +53,7 @@ struct OffsetDateTimeTests {
     }
 
     @Test
-    func test_init_from_string_error() throws {
+    func init_from_string_error() throws {
         #expect(throws: FormatError()) {
             try OffsetDateTime(from: "")
         }
@@ -86,7 +86,7 @@ struct OffsetDateTimeTests {
     }
 
     @Test
-    func test_init_from_description() {
+    func init_from_description() {
         #expect(OffsetDateTime("1970-12-31T01:02:03.000000004") == nil)
         #expect(OffsetDateTime("1970-12-31T01:02:03.000000004+01:00") == OffsetDateTime(
             dateTime: LocalDateTime(
@@ -98,7 +98,7 @@ struct OffsetDateTimeTests {
     }
 
     @Test
-    func test_init_from_decoder() throws {
+    func init_from_decoder() throws {
         #expect(try JSONDecoder().decode(OffsetDateTime.self, from: Data("\"1970-12-31T01:02:03.000000004+01:00\"".utf8)) == OffsetDateTime(
             dateTime: LocalDateTime(
                 date: LocalDate(year: 1970, month: 12, day: 31),
@@ -130,12 +130,12 @@ struct OffsetDateTimeTests {
     }
 
     @Test
-    func test_encode_to_encoder() throws {
+    func encode_to_encoder() throws {
         #expect(try JSONEncoder().encode(OffsetDateTime(year: 1970, month: 12, day: 31, hour: 1, minute: 2, second: 3, nanosecond: 4, offset: ZoneOffset(second: 3600))) == Data("\"1970-12-31T01:02:03.000000004+01:00\"".utf8))
     }
 
     @Test
-    func test_comparable() throws {
+    func comparable() throws {
         // same offset, different local date time
         #expect(try OffsetDateTime(from: "1970-01-01T00:00:00+00:00") < OffsetDateTime(from: "1970-01-01T00:00:01+00:00"))
 

--- a/Tests/LocalDateTests/YearMonthTests.swift
+++ b/Tests/LocalDateTests/YearMonthTests.swift
@@ -11,20 +11,20 @@ struct YearMonthTests {
     }
     
     @Test
-    func test_init_from_date_in_timeZone() throws {
+    func init_from_date_in_timeZone() throws {
         #expect(try YearMonth(from: Date(timeIntervalSince1970: 0), in: #require(TimeZone(secondsFromGMT: 0))) == YearMonth(year: 1970, month: 1))
         
         #expect(try YearMonth(from: Date(timeIntervalSince1970: 0), in: #require(TimeZone(secondsFromGMT: -3600))) == YearMonth(year: 1969, month: 12))
     }
     
     @Test
-    func test_init_from_string() throws {
+    func init_from_string() throws {
         #expect(try YearMonth(from: "1970-12") == YearMonth(year: 1970, month: 12))
         #expect(try YearMonth(from: "-0001-01") == YearMonth(year: -1, month: 1))
     }
     
     @Test
-    func test_init_from_string_error() {
+    func init_from_string_error() {
         #expect(throws: FormatError()) {
             try YearMonth(from: "")
         }
@@ -58,13 +58,13 @@ struct YearMonthTests {
     }
     
     @Test
-    func test_init_from_description() {
+    func init_from_description() {
         #expect(YearMonth("197001") == nil)
         #expect(YearMonth(YearMonth(year: 1970, month: 1).description) == YearMonth(year: 1970, month: 1))
     }
     
     @Test
-    func test_init_from_decoder() throws {
+    func init_from_decoder() throws {
         #expect(try JSONDecoder().decode(YearMonth.self, from: Data("\"1970-01\"".utf8)) == YearMonth(year: 1970, month: 1))
         
         #if compiler(>=6.1)
@@ -90,12 +90,12 @@ struct YearMonthTests {
     }
     
     @Test
-    func test_encode_to_encoder() throws {
+    func encode_to_encoder() throws {
         #expect(try JSONEncoder().encode(YearMonth(year: 1970, month: 1)) == Data("\"1970-01\"".utf8))
     }
     
     @Test
-    func test_comparable() {
+    func comparable() {
         #expect(YearMonth(year: 1969, month: 12) < YearMonth(year: 1970, month: 1))
         
         #expect(YearMonth(year: 1970, month: 1) < YearMonth(year: 1970, month: 2))

--- a/Tests/LocalDateTests/ZoneOffsetTests.swift
+++ b/Tests/LocalDateTests/ZoneOffsetTests.swift
@@ -10,7 +10,7 @@ struct ZoneOffsetTests {
     }
 
     @Test
-    func test_init_hour_minute() {
+    func init_hour_minute() {
         #expect(ZoneOffset(hour: 1).second == 3600)
         #expect(ZoneOffset(hour: 2, minute: 30).second == 9000)
         #expect(ZoneOffset(hour: -1).second == -3600)
@@ -18,20 +18,20 @@ struct ZoneOffsetTests {
     }
 
     @Test
-    func test_init_from_timeZone() throws {
+    func init_from_timeZone() throws {
         #expect(try ZoneOffset(timeZone: #require(TimeZone(secondsFromGMT: 3600))) == ZoneOffset(second: 3600))
         #expect(try ZoneOffset(timeZone: #require(TimeZone(secondsFromGMT: -9000))) == ZoneOffset(second: -9000))
     }
 
     @Test
-    func test_init_from_string() throws {
+    func init_from_string() throws {
         #expect(try ZoneOffset(from: "+02:30") == ZoneOffset(second: 9000))
         #expect(try ZoneOffset(from: "-02:30") == ZoneOffset(second: -9000))
         #expect(try ZoneOffset(from: "Z") == ZoneOffset(second: 0))
     }
 
     @Test
-    func test_init_from_string_error() throws {
+    func init_from_string_error() throws {
         #expect(throws: FormatError()) {
             try ZoneOffset(from: "+")
         }
@@ -57,13 +57,13 @@ struct ZoneOffsetTests {
     }
 
     @Test
-    func test_init_from_description() {
+    func init_from_description() {
         #expect(ZoneOffset("") == nil)
         #expect(ZoneOffset("-02:30") == ZoneOffset(second: -9000))
     }
 
     @Test
-    func test_init_from_decoder() throws {
+    func init_from_decoder() throws {
         #expect(try JSONDecoder().decode(ZoneOffset.self, from: Data("\"-02:30\"".utf8)) == ZoneOffset(second: -9000))
 
         #if compiler(>=6.1)
@@ -89,12 +89,12 @@ struct ZoneOffsetTests {
     }
 
     @Test
-    func test_encode_to_encoder() throws {
+    func encode_to_encoder() throws {
         #expect(try JSONEncoder().encode(ZoneOffset(second: -9000)) == Data("\"-02:30\"".utf8))
     }
 
     @Test
-    func test_comparable() {
+    func comparable() {
         // +01:00 < +00:00
         #expect(ZoneOffset(second: 3600) < ZoneOffset(second: 0))
         // +00:00 < -01:00


### PR DESCRIPTION
## Summary
- Remove the explicit SwiftFormat disable for `swiftTestingTestCaseNames` so the rule is active via the formatter defaults.
- Apply the resulting test case name updates across the Swift Testing suites.

## Testing
- `swift run swiftformat . --lint`
- `swift test`